### PR TITLE
Update stylus-loader dependency to ^2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "index.js"
   ],
   "dependencies": {
-    "stylus-loader": "^1.4.2"
+    "stylus-loader": "^2.1.1"
   },
   "author": "Jonny Buchanan <jonathan.buchanan@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
This fixes the error `Path must be a string. Received undefined` when using node 6.
